### PR TITLE
ci: bump create-github-app-token to v3.2.0 (Node 24)

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -19,7 +19,7 @@ jobs:
     name: Add opened issue/PR to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.SC_PROJECT_BOT_ID }}
@@ -34,7 +34,7 @@ jobs:
     name: Backfill open issues & PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.SC_PROJECT_BOT_ID }}


### PR DESCRIPTION
Bumps `actions/create-github-app-token` from v1.11.0 → v3.2.0 in the add-to-project workflow. v1.11.0 runs on the now-deprecated Node 20 (see the deprecation warning in run logs); v3.2.0 runs on Node 24. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)